### PR TITLE
Add support for sorting by menu config

### DIFF
--- a/src/components/shared/Main/index.tsx
+++ b/src/components/shared/Main/index.tsx
@@ -46,7 +46,7 @@ const base = (body: any) => css`
 `
 
 export const Main: FC<MainProps> = props => (
-  <SearchCtxProvider>
+  <SearchCtxProvider menuConfig={props.config.menu}>
     <Wrapper>
       <Global styles={base(get(props, 'config.themeConfig.styles.body'))} />
       {props.children}

--- a/src/components/shared/Search/SearchContext.tsx
+++ b/src/components/shared/Search/SearchContext.tsx
@@ -4,10 +4,12 @@ import { getMenusFromDocs, Menus } from '../../../utils/getMenusFromDocs'
 
 interface Props {
   docs: DocsRenderProps['docs']
+  menuConfig: string[]
 }
 
 export interface SearchContext {
   menus: Menus | []
+  menuConfig: string[]
   searching: boolean
   setSearching: (arg0: boolean) => void
   setMenus: (arg0: Menus) => void
@@ -20,8 +22,10 @@ const SearchContext = React.createContext<State | null>(null)
 class Provider extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
+
     this.state = {
-      menus: getMenusFromDocs(props.docs),
+      menus: getMenusFromDocs(props.docs, props.menuConfig),
+      menuConfig: props.menuConfig,
       searching: false,
       setMenus: this.setMenus,
       setSearching: this.setSearching,

--- a/src/components/shared/Search/index.tsx
+++ b/src/components/shared/Search/index.tsx
@@ -84,7 +84,7 @@ class SearchInput extends Component<SidebarProps, SidebarState> {
     return (
       <Docs>
         {({ docs }) => {
-          const initial = getMenusFromDocs(docs)
+          const initial = getMenusFromDocs(docs, this.props.menuConfig)
           const menus = this.props.menus || initial
 
           return (

--- a/src/utils/getMenusFromDocs.ts
+++ b/src/utils/getMenusFromDocs.ts
@@ -43,7 +43,7 @@ const sortByOrder = (a: Menu, b: Menu) => {
   return 0
 }
 
-const getMenusFromDocs = (docs: Entry[]): Menus => {
+const getMenusFromDocs = (docs: Entry[], menuConfig: string[]): Menus => {
   const uniqueMenus: { [key: string]: Menu } = {}
   const delimiter = '__'
   const rootItems: Entry[] = []
@@ -148,6 +148,12 @@ const getMenusFromDocs = (docs: Entry[]): Menus => {
   }))
 
   const menuArray = new Array().concat(menus, rootItems)
+
+  // sort by menuConfig from doczrc.js if it exists. Fallback to alphabetical ordering
+  // if no custom menu order is provided
+  if (Array.isArray(menuConfig)) {
+    return menuConfig.map(x => menuArray.find(item => item.name === x)).filter(Boolean);
+  }
 
   sort(menuArray, sortByOrder, 'name')
 


### PR DESCRIPTION
Add support for sorting by the `menu` property of `docz`.

```
// doczrc.js
{
  menu: [
    'Getting Started',
    'Definition',
    'Examples',
  ],
}
```

Without this change, `hydrate` would render on alphabetic order (`Definition`, `Examples`, `Getting Started`).

Submenu order is not touched. And without this config setting, the behaviour is as usual.

A more complete fix, would be to also add support for submenu order, and creation of external links. As `docz` supports. But that's a nice one for another PR.

See: https://github.com/pedronauck/docz/releases/tag/v0.12.4