### PR TITLE
Fix emotion innerRef deprecation warning

### DIFF
--- a/src/components/shared/Sidebar/Menu.tsx
+++ b/src/components/shared/Sidebar/Menu.tsx
@@ -115,7 +115,7 @@ export class Menu extends Component<MenuProps, MenuState> {
         hasMenus={hasMenus}
         opened={show}
         level={level}
-        innerRef={(node: any) => {
+        ref={(node: any) => {
           this.menu = node
         }}
       >

--- a/src/components/shared/Sidebar/MenuLink.tsx
+++ b/src/components/shared/Sidebar/MenuLink.tsx
@@ -96,7 +96,6 @@ interface LinkProps {
   item: Menu | Entry
   onClick?: React.MouseEventHandler<any>
   className?: string
-  innerRef?: (node: any) => void
   isItem?: boolean
   onMouseEnter?: (ev: React.SyntheticEvent<any>) => void
   onMouseLeave?: (ev: React.SyntheticEvent<any>) => void
@@ -132,7 +131,6 @@ export class MenuLink extends Component<LinkProps, LinkState> {
       item,
       children,
       onClick,
-      innerRef,
       isItem,
       onMouseEnter,
       onMouseLeave,
@@ -143,8 +141,7 @@ export class MenuLink extends Component<LinkProps, LinkState> {
       children,
       onClick,
       className: linkStyle({ ...config.themeConfig, isItem, level }),
-      innerRef: (node: any) => {
-        innerRef && innerRef(node)
+      ref: (node: any) => {
         this.$el = node
       },
     })
@@ -159,20 +156,20 @@ export class MenuLink extends Component<LinkProps, LinkState> {
         <ThemeConfig>
           {config => {
             const route: any = item.route === '/' ? '/' : item.route
-            const props = { ...commonProps(config) }
+            const { ref, ...props } = { ...commonProps(config) }
 
             if (item.type === 'external-link') {
-              return <LinkAnchor {...props} icon={item.icon} href={item.href} />
+              return <LinkAnchor ref={ref} {...props} icon={item.icon} href={item.href} />
             }
 
             if (item.route) {
               if (location.hash) {
                 props.activeClassName = 'active no-highlight'
               }
-              return <Link {...props} to={route} />
+              return <Link innerRef={ref} {...props} to={route} />
             }
 
-            return <LinkAnchor {...props} href="#" />
+            return <LinkAnchor ref={ref} {...props} href="#" />
           }}
         </ThemeConfig>
         {active && item.route && <MenuHeadings route={item.route} />}

--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SFC } from 'react'
+import { FC, forwardRef } from 'react'
 import styled from '@emotion/styled'
 import { Link as BaseLink } from 'docz'
 
@@ -20,13 +20,14 @@ export const LinkStyled = styled('a')`
 
 type LinkProps = React.AnchorHTMLAttributes<any>
 
-export const Link: SFC<LinkProps> = ({ href, ...props }) => {
+const StyledBaseLink = LinkStyled.withComponent(BaseLink)
+
+export const Link: FC<LinkProps> = ({ href, innerRef, ...props }) => {
   const isInternal = href && href.startsWith('/')
-  const Component = isInternal ? LinkStyled.withComponent(BaseLink) : LinkStyled
 
   return isInternal ? (
-    <Component {...props} to={href} />
+    <StyledBaseLink ref={innerRef} {...props} to={href} />
   ) : (
-    <Component {...props} href={href} />
+    <LinkStyled ref={innerRef} {...props} href={href} />
   )
 }


### PR DESCRIPTION
The upgrade of emotion (PR #10) introduced a deprecation warning for 'innerRef' usage.

This PR fixes that warning by migrating them to `ref`.